### PR TITLE
Fix raw query placeholder for Pg SQL

### DIFF
--- a/lib/connect-session-knex.js
+++ b/lib/connect-session-knex.js
@@ -133,7 +133,7 @@ KnexStore.prototype.set = function(sid, sess, fn) {
 	var expired = maxAge ? now + maxAge : now + oneDay;
 	sess = JSON.stringify(sess);
 	var postgresfastq = 'with new_values (sid, expired, sess) as (' +
-					'  values ($1, $2::timestamp without time zone, $3::json)' +
+					'  values (?, ?::timestamp without time zone, ?::json)' +
 					'), ' +
 					'upsert as ' +
 					'( ' +


### PR DESCRIPTION
Thanks for this. I tried using it in a project with Postgres but kept on coming across an error, and managed to fix it myself so thought I'd fire off a pull request for you.

Knex uses `?` for raw query placeholders, however the script was using `$1`, `$2` etc. for Postgresql.

Without them, Knex would throw,

```Unhandled rejection Error: Expected 3 bindings, saw 0
    at replaceRawArrBindings (/Users/dan/git/travelstories/node_modules/knex/lib/raw.js:96:11)
    at Raw.assign.toSQL (/Users/dan/git/travelstories/node_modules/knex/lib/raw.js:50:22)
    at /Users/dan/git/travelstories/node_modules/knex/lib/runner.js:35:32
    at /Users/dan/git/travelstories/node_modules/knex/node_modules/bluebird/js/main/using.js:165:30
    at tryCatcher (/Users/dan/git/travelstories/node_modules/knex/node_modules/bluebird/js/main/util.js:24:31)
    at Promise.module.exports.Promise._settlePromiseFromHandler (/Users/dan/git/travelstories/node_modules/knex/node_modules/bluebird/js/main/promise.js:454:31)
    at Promise.module.exports.Promise._settlePromiseAt (/Users/dan/git/travelstories/node_modules/knex/node_modules/bluebird/js/main/promise.js:530:18)
    at Promise.module.exports.Promise._settlePromises (/Users/dan/git/travelstories/node_modules/knex/node_modules/bluebird/js/main/promise.js:646:14)
    at Async._drainQueue (/Users/dan/git/travelstories/node_modules/knex/node_modules/bluebird/js/main/async.js:177:16)
    at Async._drainQueues (/Users/dan/git/travelstories/node_modules/knex/node_modules/bluebird/js/main/async.js:187:10)
    at Immediate.drainQueues [as _onImmediate] (/Users/dan/git/travelstories/node_modules/knex/node_modules/bluebird/js/main/async.js:15:14)
    at processImmediate [as _immediateCallback] (timers.js:358:17)```