### PR TITLE
Postgres < 9.2 doesn't support the JSON type

### DIFF
--- a/index.js
+++ b/index.js
@@ -171,7 +171,7 @@ KnexStore.prototype.set = function(sid, sess, fn) {
 				throw err;
 			});
 		});
-	} else if (self.knex.client.dialect === 'postgresql') {
+	} else if (self.knex.client.dialect === 'postgresql' && parseFloat(self.knex.client.version) >= 9.2) {
 		// postgresql optimized query
 		return self.ready.then(function () {
 			return self.knex.raw(postgresfastq, [sid, new Date(expired).toISOString(), sess ])


### PR DESCRIPTION
Postgres [only introduced the JSON type in version 9.2](http://www.postgresql.org/docs/9.2/static/datatype-json.html).

The knex session store set method uses a raw query which assumes the JSON type when using the postgres client. On postgres 9.1 this fails with 'type "json" does not exist'.

This quick fix checks the postgres version in the same way that [knex](https://github.com/tgriesser/knex/blob/0.8.6/src/dialects/postgres/schema/columncompiler.js#L39) does, and doesn't use the raw query if the version is less than 9.2.