### PR TITLE
Date.toISOString() does not output a supported string for mysql.

### DIFF
--- a/index.js
+++ b/index.js
@@ -187,7 +187,7 @@ KnexStore.prototype.set = function(sid, sess, fn) {
 	} else if (['mysql', 'mariasql'].indexOf(self.knex.client.dialect) > -1) {
 		// mysql/mariaDB optimized query
 		return self.ready.then(function () {
-			return self.knex.raw(mysqlfastq, [sid, new Date(expired).toISOString(), sess ])
+			return self.knex.raw(mysqlfastq, [sid, new Date(expired).toISOString().slice(0, 19).replace('T', ' '), sess ])
 			.then(function (result) {
 				if (fn) fn(null, result);
 				return result;


### PR DESCRIPTION
Updated to use supported datetime format. See http://stackoverflow.com/questions/12114201/iso-8601-timestamp-for-mysql-database-mysql-incorrect-datetime-value and http://stackoverflow.com/questions/11053941/mysql-insert-to-datetime-is-it-safe-to-use-iso8601-format for details.