### PR TITLE
postgresql - query timestamps with timezone

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,8 @@ module.exports = function(connect) {
 	* @api private
 	*/
 	function timestampTypeName(knex) {
-		return (['mysql', 'mariasql', 'mariadb'].indexOf(knex.client.dialect) > -1) ? 'DATETIME' : 'timestamp';
+		return (['mysql', 'mariasql', 'mariadb'].indexOf(knex.client.dialect) > -1) ? 'DATETIME' :
+      knex.client.dialect === 'postgresql' ? 'timestamp with time zone' : 'timestamp';
 	}
 
 	/*


### PR DESCRIPTION
Fixes timestamp issues from #11 

Per http://www.postgresql.org/docs/9.1/static/datatype-datetime.html:

> The SQL standard requires that writing just timestamp be equivalent to timestamp without time zone, and PostgreSQL honors that behavior. (Releases prior to 7.3 treated it as timestamp with time zone.) timestamptz is accepted as an abbreviation for timestamp with time zone; this is a PostgreSQL extension.

This means you also have to query back `timestamp with time zone`.