### PR TITLE
Fix bluebird missing return warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,17 @@ node_js:
   - "0.12"
   - "0.10"
 
+env:
+  - CXX=g++-4.8
+
 before_script:
   - psql -c 'create database travis_ci_test;' -U postgres
   - mysql -e 'create database travis_ci_test;'
 
 addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    packages:
+    - g++-4.8
   postgresql: "9.3"

--- a/index.js
+++ b/index.js
@@ -117,10 +117,12 @@ module.exports = function(connect) {
 					}
 				});
 			}
+			return exists;
 		})
 		.then(function () {
 			dbCleanup(self);
 			self._clearer = setInterval(dbCleanup, options.clearInterval, self).unref();
+			return null;
 		});
 	}
 


### PR DESCRIPTION
Fixes `Warning: a promise was created in a handler but was not returned from it` that Bluebird emits when a promise handler doesn't return a value.