### PR TITLE
Add ability to disable automatic table creation

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -30,9 +30,10 @@ $ npm install connect-session-knex
 
  - `tablename='sessions'` Tablename to use. Defaults to 'sessions'.
  - `knex` knex instance to use. Defaults to a new knex instance, using sqlite3 with a file named 'connect-session-knex.sqlite'
+ - `createtable` if the table for sessions should be created automatically or not.
  - `clearInterval` milliseconds between clearing expired sessions. Defaults to 60000.
 
-If the table does not exist in the schema, this module will attempt to create it.
+If the table does not exist in the schema, this module will attempt to create it unless the 'createtable' option is false.
 
 If a knex instance is not provided, this module will attempt to create a sqlite3 database, with a file named 'connect-session-knex.sqlite', in the working directory of the process.
 

--- a/index.js
+++ b/index.js
@@ -95,6 +95,7 @@ module.exports = function(connect) {
 			options.clearInterval =  60000;
 		}
 
+		self.createtable = options.hasOwnProperty('createtable') ? options.createtable :  true;
 		self.tablename = options.tablename || 'sessions';
 		self.knex = options.knex || require('knex')({
 			client: 'sqlite3',
@@ -106,7 +107,7 @@ module.exports = function(connect) {
 
 		self.ready = self.knex.schema.hasTable(self.tablename)
 		.then(function (exists) {
-			if (!exists) {
+			if (!exists && self.createtable) {
 				return self.knex.schema.createTable(self.tablename, function (table) {
 					table.string('sid').primary();
 					table.json('sess').notNullable();


### PR DESCRIPTION
This adds in the ability to disable the automatic creation of the `sessions` table by providing a `createtable: false` to the options.

Used mainly if you manage your own migrations for the sessions table and wish to make sure that it's not created when using the module.