### PR TITLE
Don't clear the sessions table if the table doesn't exist

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,9 +120,11 @@ module.exports = function(connect) {
 			}
 			return exists;
 		})
-		.then(function () {
-			dbCleanup(self);
-			self._clearer = setInterval(dbCleanup, options.clearInterval, self).unref();
+		.then(function (exists) {
+			if (exists) {
+				dbCleanup(self);
+				self._clearer = setInterval(dbCleanup, options.clearInterval, self).unref();
+			}
 			return null;
 		});
 	}


### PR DESCRIPTION
This is a follow up to my previous PR to allow disabling the creating of the sessions table.

Had issues in testing where tables would migrate and rollback for each test, which meant that while the watcher was running, constant streams of errors from the cleaner function were triggering as the sessions table didn't exist.

This simply adds in a check that the table exists before it runs and sets up the cleaner.