### PR TITLE
Added option to specify sid field name

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -29,6 +29,7 @@ $ npm install connect-session-knex
 ## Options
 
  - `tablename='sessions'` Tablename to use. Defaults to 'sessions'.
+ - `sidfieldname='sid'` Field name in table to use for storing session ids. Defaults to 'sid'.
  - `knex` knex instance to use. Defaults to a new knex instance, using sqlite3 with a file named 'connect-session-knex.sqlite'
  - `createtable` if the table for sessions should be created automatically or not.
  - `clearInterval` milliseconds between clearing expired sessions. Defaults to 60000.


### PR DESCRIPTION
This adds in the ability to change the name of the sid field by providing a `sidfieldname: 'id'` option.

Useful in projects where all id fields in system have the same name and the sessions table is to be used even outside of the module (for, say, reading session data for analytics).