### PR TITLE
Add index to `expired` column

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -38,8 +38,6 @@ If the table does not exist in the schema, this module will attempt to create it
 
 If a knex instance is not provided, this module will attempt to create a sqlite3 database, with a file named 'connect-session-knex.sqlite', in the working directory of the process.
 
-This module does not create any indexes. You should create an index on the 'expired' column to make the session clearing efficient.
-
 ## Schema
 
 ### PostgreSQL or SQLite
@@ -50,8 +48,10 @@ This module does not create any indexes. You should create an index on the 'expi
 | sid     | character varying(255)   | not null  | extended |
 | sess    | json                     | not null  | extended |
 | expired | timestamp with time zone | not null  | plain    |  
-`Indexes:
-    "sessions_pkey" PRIMARY KEY, btree (sid)`
+Indexes:  
+    "sessions_pkey" PRIMARY KEY, btree (sid)  
+    "sessions_expired_index" btree (expired)
+
 
 ## Benchmarks
 

--- a/index.js
+++ b/index.js
@@ -135,9 +135,9 @@ module.exports = function(connect) {
 					table.string(self.sidfieldname).primary();
 					table.json('sess').notNullable();
 					if (['mysql', 'mariasql'].indexOf(self.knex.client.dialect) > -1) {
-						table.dateTime('expired').notNullable();
+						table.dateTime('expired').notNullable().index();
 					} else {
-						table.timestamp('expired').notNullable();
+						table.timestamp('expired').notNullable().index();
 					}
 				});
 			}


### PR DESCRIPTION
> This module does not create any indexes. You should create an index on the 'expired' column to make the session clearing efficient.

Is there any particular reason this is suggested but not implemented? Looking at the [Knex documentation](http://knexjs.org/#Schema-index) it looks like this would be a trivial addition. I gave it a shot (in PostgreSQL only, I didn't try this in the other supported DBs) and it seemed to work as expected for my table.

```
min_auth_development=> \d+ sessions
                               Table "min_auth.sessions"
 Column  |           Type           | Modifiers | Storage  | Stats target | Description
---------+--------------------------+-----------+----------+--------------+-------------
 sid     | character varying(255)   | not null  | extended |              |
 sess    | json                     | not null  | extended |              |
 expired | timestamp with time zone | not null  | plain    |              |
Indexes:
    "sessions_pkey" PRIMARY KEY, btree (sid)
    "sessions_expired_index" btree (expired)
```

Disclaimer: I know relatively little about databases, so perhaps there is something about indexing on a timestamp which is more complicated that this?