### PR TITLE
added stopDbCleanup

### DIFF
--- a/index.js
+++ b/index.js
@@ -173,7 +173,7 @@ module.exports = function(connect) {
 			return store.knex(store.tablename).del()
 			.whereRaw(condition, dateAsISO(store.knex));
 		}).finally(function() {
-			setTimeout(dbCleanup, interval, store, interval).unref();
+			KnexStore.nextDbCleanup = setTimeout(dbCleanup, interval, store, interval).unref();
 		});
 	}
 
@@ -415,6 +415,14 @@ module.exports = function(connect) {
 			.from(self.tablename)
 			.asCallback(fn);
 		});
+	};
+
+	/* stop the dbCleanupTimeout */
+	KnexStore.prototype.stopDbCleanup = function(){
+		if(KnexStore.nextDbCleanup){
+			clearTimeout(KnexStore.nextDbCleanup);
+			delete KnexStore.nextDbCleanup;
+		}
 	};
 
 	return KnexStore;


### PR DESCRIPTION
So, in my tests I open and close databases and sometimes delete them so I needed a way of stopping these after I had closed the database.