### PR TITLE
Fix missing argument on next tick of dbCleanup

### DIFF
--- a/index.js
+++ b/index.js
@@ -244,6 +244,7 @@ function dbCleanup(store, interval, KnexStore) {
         interval,
         store,
         interval,
+        KnexStore,
       ).unref();
     });
 }


### PR DESCRIPTION
This PR fixes a problem I encountered when the next tick of dbCleanup runs.

```
(node:4432) UnhandledPromiseRejectionWarning: TypeError: Cannot set property 'nextDbCleanup' of undefined
    at C:\Dev\sample_app\node_modules\connect-session-knex\index.js:242:31
    at <anonymous>
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
(Use `node --trace-warnings ...` to show where the warning was created)
(node:4432) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(
). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:4432) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

--- Edit ---

More debug details:

The KnexStore is defined on the first run

![image](https://user-images.githubusercontent.com/8093279/83935929-a39a0580-a794-11ea-9efa-dd68c6b7261c.png)

But when the next tick runs from the scheduled setTimeout the KnexStore is undefined:

![image](https://user-images.githubusercontent.com/8093279/83935942-d5ab6780-a794-11ea-83f0-4a3adcc92c79.png)
