### PR TITLE
Fixing createtable option always defaulting to true

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -82,7 +82,7 @@ module.exports = function (connect) {
       options.clearInterval = 60000;
     }
 
-    self.createtable = Object.prototype.hasOwnProperty.call(options, 'creatable')
+    self.createtable = Object.prototype.hasOwnProperty.call(options, 'createtable')
       ? options.createtable
       : true;
     self.tablename = options.tablename || 'sessions';


### PR DESCRIPTION
`createtable` was spelled wrong so it was always getting set to true.