### PR TITLE
Fix typings for createtable option

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog and this project adheres to Semantic Versioning.
 
+**2.0.0**
+- Bug fix: https://github.com/llambda/connect-session-knex/pull/73 (As this fix is a typing change, a major version was incremented)
+
 **1.7.3**
 - Bug fix: https://github.com/llambda/connect-session-knex/pull/68
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "connect-session-knex",
-  "version": "1.7.3",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "connect-session-knex",
   "description": "A knex.js session store for Express and Connect",
-  "version": "1.7.3",
+  "version": "2.0.0",
   "main": "lib/index.js",
   "typings": "typings/index.d.ts",
   "engines": {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -6,7 +6,7 @@ declare module 'connect-session-knex' {
         tablename?: string;
         sidfieldname?: string;
         knex?: Knex;
-        createTable?: boolean;
+        createtable?: boolean;
         clearInterval?: number;
     };
 


### PR DESCRIPTION
In docs and code the option is supposed to be createtable instead of createTable specified by the types.