### PR TITLE
Update example-postgres.mjs

### DIFF
--- a/examples/example-postgres.mjs
+++ b/examples/example-postgres.mjs
@@ -18,7 +18,7 @@ const knex = knexConstructor({
 
 const store = new ConnectSessionKnexStore({
   knex,
-  tablename: "sessions", // optional. Defaults to 'sessions'
+  tableName: "sessions", // optional. Defaults to 'sessions'
 });
 
 app.use(


### PR DESCRIPTION
typo on tablename, the correct spelling is tableName